### PR TITLE
Add login host override to plist config

### DIFF
--- a/Templates/HybridAppTemplate/__HybridTemplateAppName__/__HybridTemplateAppName__/__HybridTemplateAppName__-Info.plist
+++ b/Templates/HybridAppTemplate/__HybridTemplateAppName__/__HybridTemplateAppName__/__HybridTemplateAppName__-Info.plist
@@ -54,5 +54,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>SFDCOAuthLoginHost</key>
+	<string>login.salesforce.com</string>
 </dict>
 </plist>

--- a/Templates/NativeAppTemplate/__NativeTemplateAppName__/__NativeTemplateAppName__/__NativeTemplateAppName__-Info.plist
+++ b/Templates/NativeAppTemplate/__NativeTemplateAppName__/__NativeTemplateAppName__/__NativeTemplateAppName__-Info.plist
@@ -54,5 +54,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>SFDCOAuthLoginHost</key>
+	<string>login.salesforce.com</string>
 </dict>
 </plist>


### PR DESCRIPTION
Templates were missing the plist key that allows you to override the login host.
