### PR TITLE
Updating package version to 2.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "forceios",
-	"version": "2.1.1",
+	"version": "2.1.2",
 	"description": "Utilities for creating mobile apps based on the Salesforce Mobile SDK for iOS",
 	"keywords": [ "mobilesdk", "ios", "salesforce", "mobile", "sdk" ],
 	"homepage": "https://github.com/forcedotcom/SalesforceMobileSDK-iOS",


### PR DESCRIPTION
npmjs.org never showed the 2.1.1 version, despite the fact that I published it.  And you can't re-publish the same version number.  So 2.1.2 it is.  Hopefully that will go better than the previous version publish did.
